### PR TITLE
Add inaddr.h header file

### DIFF
--- a/libc/include/arpa/inet.h
+++ b/libc/include/arpa/inet.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
+#include <inaddr.h>
 
 __BEGIN_DECLS
 

--- a/libc/include/inaddr.h
+++ b/libc/include/inaddr.h
@@ -26,19 +26,11 @@
  * SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef _INADDR_H_
+#define _INADDR_H_
 
-/**
- * @file bits/in_addr.h
- * @brief IPv4 address types.
- */
-
-#include <sys/cdefs.h>
 #include <stdint.h>
 
-#include <inaddr.h>
+typedef uint32_t in_addr_t;
 
-/** A structure representing an IPv4 address. */
-struct in_addr {
-  in_addr_t s_addr;
-};
+#endif


### PR DESCRIPTION
bionic/libc/include/arpa/inet.h:39:1: error: unknown type name 'in_addr_t'
in_addr_t inet_addr(const char* __s);
^
bionic/libc/include/arpa/inet.h:41:1: error: unknown type name 'in_addr_t'
in_addr_t inet_lnaof(struct in_addr __addr) __INTRODUCED_IN(21);
^
bionic/libc/include/arpa/inet.h:42:30: error: unknown type name 'in_addr_t'
struct in_addr inet_makeaddr(in_addr_t __net, in_addr_t __host) __INTRODUCED_IN(21);
                             ^
bionic/libc/include/arpa/inet.h:42:47: error: unknown type name 'in_addr_t'
struct in_addr inet_makeaddr(in_addr_t __net, in_addr_t __host) __INTRODUCED_IN(21);
                                              ^
bionic/libc/include/arpa/inet.h:43:1: error: unknown type name 'in_addr_t'
in_addr_t inet_netof(struct in_addr __addr) __INTRODUCED_IN(21);
^
bionic/libc/include/arpa/inet.h:44:1: error: unknown type name 'in_addr_t'
in_addr_t inet_network(const char* __s) __INTRODUCED_IN(21);
^